### PR TITLE
Order changed files by path

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -67,6 +67,6 @@ def render_changeset(request, repository, changeset):
     context = {
       "repository": repository,
       "changeset": changeset,
-      "changes": changeset.changes.all(),
+      "changes": sorted(changeset.changes.all(), cmp=lambda x,y: cmp(x.path.path, y.path.path)),
     }
     return render(request, "changeset.html", context)


### PR DESCRIPTION
Files changed by a changeset aren't ordered at all, which is unhelpful. Example: http://hgchanges.fractalbrew.com/comm-central/rev/74916ecc3d77
